### PR TITLE
Mistakenly used tidycensus::census_api_key

### DIFF
--- a/R/01_2018-01-09_ACS_Import.R
+++ b/R/01_2018-01-09_ACS_Import.R
@@ -23,7 +23,7 @@ library( rgdal )
 
 # assumption that a census api key is already installed on your system
 # here, the key is stored as CENSUS_API_KEY=YOURKEY in the .Renviron file
-  census_api_key( key = Sys.getenv( x = "CENSUS_API_KEY" ) )
+api.key.install( key = Sys.getenv( x = "CENSUS_API_KEY" ) )
 
 
 # Table Shells for ACS 2012-2016 5-Year Estimate Data


### PR DESCRIPTION
Used incorrect command from another package (`tidycensus`) rather than the same command within the `acs` package.